### PR TITLE
fix(sdk): set the hideNavigation param correctly for embeds

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,19 +1,19 @@
-# StackBlitz - SDK
+# StackBlitz SDK
 
 Wouldn't it be great if you could create StackBlitz projects on-demand from your docs, examples, blog posts?
 
-This is exactly what the StackBlitz SDK allows you to do. Even better, the SDK even gives you full control of the StackBlitz VM- allowing you to build rich & interactive experiences around your projects. 😮 🙌
+This is exactly what the StackBlitz SDK allows you to do. Even better, the SDK even gives you full control of the StackBlitz VM - allowing you to build rich & interactive experiences around your projects. 😮 🙌
 
-The SDK is **2kb gzipped** (!) and you can install it from NPM:
+The SDK is **2kb gzipped** (!) and you can install it from npm:
 
 ```sh
 npm install --save @stackblitz/sdk
 ```
 
-Or add a script tag to the UMD build on jsDelivr/Unpkg — the SDK will be available on window as `StackBlitzSDK`:
+Or add a script tag to the UMD build on jsDelivr/Unpkg — the SDK will be available on `window` as `StackBlitzSDK`:
 
 ```html
 <script src="https://unpkg.com/@stackblitz/sdk/bundles/sdk.umd.js"></script>
 ```
 
-### Learn more at [stackblitz.com/docs](https://stackblitz.com/docs#javascript-sdk)
+**Learn more on [developer.stackblitz.com](https://developer.stackblitz.com/docs/platform/javascript-sdk)**

--- a/sdk/src/helpers.ts
+++ b/sdk/src/helpers.ts
@@ -12,49 +12,47 @@ export function genID() {
 }
 
 export function buildProjectQuery(options?: EmbedOptions){
-  let queryParams = '';
+  const params = [];
 
-  if(!options){
-    return queryParams;
+  if(options){
+    if(options.forceEmbedLayout) {
+      params.push('embed=1');
+    }
+
+    if(options.clickToLoad){
+      params.push('ctl=1');
+    }
+
+    if(typeof options.openFile === 'string'){
+      params.push(`file=${options.openFile}`);
+    }
+
+    if(options.view === 'preview' || options.view === 'editor'){
+      params.push(`view=${options.view}`);
+    }
+
+    if(options.theme === 'light' || options.theme === 'dark'){
+      params.push(`theme=${options.theme}`);
+    }
+
+    if(options.hideExplorer){
+      params.push('hideExplorer=1');
+    }
+
+    if(options.hideNavigation){
+      params.push('hideNavigation=1');
+    }
+
+    if(options.hideDevTools){
+      params.push('hidedevtools=1');
+    }
+
+    if(typeof options.devToolsHeight === 'number' && options.devToolsHeight >= 0 && options.devToolsHeight <= 100){
+      params.push(`devtoolsheight=${Math.round(options.devToolsHeight)}`);
+    }
   }
 
-  if(options.forceEmbedLayout) {
-    queryParams += 'embed=1';
-  }
-
-  if(options.clickToLoad){
-    queryParams += `${queryParams.length ? '&' : ''}ctl=1`;
-  }
-
-  if(options.openFile){
-    queryParams += `${queryParams.length ? '&' : ''}file=${options.openFile}`;
-  }
-
-  if(options.view && (options.view === 'preview' || options.view === 'editor')){
-    queryParams += `${queryParams.length ? '&' : ''}view=${options.view}`;
-  }
-
-  if(options.theme){
-    queryParams += `${queryParams.length ? '&' : ''}theme=${options.theme}`;
-  }
-
-  if(options.hideExplorer){
-    queryParams += `${queryParams.length ? '&' : ''}hideExplorer=1`;
-  }
-
-  if(options.hideNavigation){
-    queryParams += `${queryParams.length ? '&' : ''}hideNavigation=1;`;
-  }
-
-  if(options.hideDevTools){
-    queryParams += `${queryParams.length ? '&' : ''}hidedevtools=1`;
-  }
-
-  if(typeof options.devToolsHeight === 'number' && options.devToolsHeight > 0 && options.devToolsHeight < 100){
-    queryParams += `${queryParams.length ? '&' : ''}devtoolsheight=${options.devToolsHeight}`;
-  }
-
-  return queryParams.length ? `?${queryParams}` : queryParams;
+  return params.length ? `?${params.join('&')}` : '';
 }
 
 export function replaceAndEmbed(parent: HTMLElement, frame: HTMLIFrameElement, options?: EmbedOptions){


### PR DESCRIPTION
We have a bug with the `hideNavigation` option for embed methods.

Instead of adding `hideNavigation=1` to the URL, we add `hideNavigation=1;`, resulting in a value of `1;` which gets ignored by the StackBlitz editor.

This PR fixes this issue, and constructs the query string by joining an array of `key=value` strings instead of adding having to deal with adding `&` or not for each parameter.

There are a couple other changes:

1. The `theme` parameter is restricted to `'light'` or `'dark'`. Though maybe we should accept any string, even though we're not supporting other values? Happy to roll back that change if we want to keep it open. (I’m noticing that it's not documented on https://developer.stackblitz.com/docs/platform/javascript-sdk/#embed-options yet?)

2. The `devtoolsheight` option now accepts the values `0` and `100`. In particular, I’ve seen users of the SDK use `devToolsHeight: 99` because `100` was filtered out by the SDK, even though `devtoolsheight=100` in the URL does work.