### PR TITLE
feat: add GitHub Action to close empty issues

### DIFF
--- a/.github/workflows/close-empty-issues.yml
+++ b/.github/workflows/close-empty-issues.yml
@@ -1,0 +1,18 @@
+on:
+  issues:
+    types: [opened]
+jobs:
+  closeEmptyIssues:
+    if: "${{ github.event.issue.body == '' }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: close empty issues
+        # v1.0.0
+        uses: kerhub/saved-replies@dd3633c3608fcc768978988b012871d66f98f7d6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          state: 'closed'
+          reply: |
+            A minimal context is required to triage your issue.
+
+            Please open a new issue using one of our templates available [here](https://github.com/stackblitz/core/issues/new/choose)


### PR DESCRIPTION
## Description

This pull request adds a GitHub Action to moderate issues opened with an empty body.

When an issue is opened, this GitHub Action is triggered and if the body is empty, it closes the issue without any manual action required.

As some people might just not be used to communication standards and the requirement of a minimal context, I added a message to be added to the issue while closing it:

```
A minimal context is required to triage your issue.

Please open a new issue using one of our templates available [here](https://github.com/stackblitz/core/issues/new/choose)
```

@purplem1lk Feel free to provide feedback about this message to update it to match your needs.

## Motivation

On a regular basis, issues are opened in this repository without any content in the issue body to provide the required context to understand the motivation of such an issue.

There are two common situations:
- issues only providing a link to a GitHub repository/Stackblitz project without explanation
- issues opened by new GitHub users and unrelated with the repository