### PR TITLE
sdk: fix relative import paths in emmited types

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackblitz/sdk",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "",
   "main": "./bundles/sdk.js",
   "module": "./bundles/sdk.m.js",

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,41 +1,60 @@
 import { Project, OpenOptions, EmbedOptions } from './interfaces';
 import { Connection, getConnection } from './connection';
 import { openProject, createProjectFrameHTML } from './generate';
-import { replaceAndEmbed, buildProjectQuery, elementFromElementOrId, openTarget, getOrigin } from './helpers';
+import {
+  replaceAndEmbed,
+  buildProjectQuery,
+  elementFromElementOrId,
+  openTarget,
+  getOrigin,
+} from './helpers';
+import { VM } from './VM';
 
 const StackBlitzSDK = {
-  connect: (frameEl: HTMLIFrameElement) => {
+  connect(frameEl: HTMLIFrameElement): Promise<VM> {
     // Validate whether this is a legit iframe on the page.
-    if (!frameEl || !frameEl.contentWindow)
+    if (!frameEl || !frameEl.contentWindow) {
       return Promise.reject('Provided element is not an iframe.');
+    }
 
     // If it's an iframe, first check if there's already a connection for it
     const currentConnection = getConnection(frameEl);
-
-    // If no active connection, create one.
-    if (!currentConnection) {
-      const connection = new Connection(frameEl);
-      return connection.pending;
-    // If there IS an active connection, return the current connection instance.
-    // Unless it's pending
-    } else {
+    if (currentConnection) {
       return currentConnection.pending;
     }
+
+    // If no active connection, create one.
+    const connection = new Connection(frameEl);
+    return connection.pending;
   },
 
   // Open in new tab methods
-  openGithubProject: (repoSlug: string, options?: OpenOptions) => {
-    window.open(`${getOrigin(options)}/github/${repoSlug}${buildProjectQuery(options)}`, openTarget(options));
+
+  openGithubProject(repoSlug: string, options?: OpenOptions) {
+    window.open(
+      `${getOrigin(options)}/github/${repoSlug}${buildProjectQuery(options)}`,
+      openTarget(options)
+    );
   },
-  openProject: (project: Project, options?: OpenOptions) => {
+
+  openProject(project: Project, options?: OpenOptions) {
     openProject(project, options);
   },
-  openProjectId: (projectId: string, options?: OpenOptions) => {
-    window.open(`${getOrigin(options)}/edit/${projectId}${buildProjectQuery(options)}`, openTarget(options));
+
+  openProjectId(projectId: string, options?: OpenOptions) {
+    window.open(
+      `${getOrigin(options)}/edit/${projectId}${buildProjectQuery(options)}`,
+      openTarget(options)
+    );
   },
 
   // Embed on page methods
-  embedGithubProject: (elementOrId: string | HTMLElement, repoSlug: string, options?: EmbedOptions) => {
+
+  embedGithubProject(
+    elementOrId: string | HTMLElement,
+    repoSlug: string,
+    options?: EmbedOptions
+  ): Promise<VM> {
     const element = elementFromElementOrId(elementOrId);
     const frame = document.createElement('iframe');
     frame.src = `${getOrigin(options)}/github/${repoSlug}${buildProjectQuery(options)}`;
@@ -44,7 +63,12 @@ const StackBlitzSDK = {
 
     return StackBlitzSDK.connect(frame);
   },
-  embedProject: (elementOrId: string | HTMLElement, project: Project, options?: EmbedOptions) => {
+
+  embedProject(
+    elementOrId: string | HTMLElement,
+    project: Project,
+    options?: EmbedOptions
+  ): Promise<VM> {
     const element = elementFromElementOrId(elementOrId);
     const html = createProjectFrameHTML(project, options);
     const frame = document.createElement('iframe');
@@ -56,7 +80,12 @@ const StackBlitzSDK = {
 
     return StackBlitzSDK.connect(frame);
   },
-  embedProjectId: (elementOrId: string | HTMLElement, projectId: string, options?: EmbedOptions) => {
+
+  embedProjectId(
+    elementOrId: string | HTMLElement,
+    projectId: string,
+    options?: EmbedOptions
+  ): Promise<VM> {
     const element = elementFromElementOrId(elementOrId);
     const frame = document.createElement('iframe');
     frame.src = `${getOrigin(options)}/edit/${projectId}${buildProjectQuery(options)}`;
@@ -64,8 +93,7 @@ const StackBlitzSDK = {
     replaceAndEmbed(element, frame, options);
 
     return StackBlitzSDK.connect(frame);
-  }
-}
-
+  },
+};
 
 export default StackBlitzSDK;


### PR DESCRIPTION
Aims to fix #1721.

- Explicitly import the VM type and explicitly declare the `Promise<VM>` return type for functions that return that promise.
- Other changes in `sdk/src/index.ts` are Prettier formatting plus a couple stylistic changes.