### PR TITLE
fix(sdk): explicit array type needed for tsc compilation

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stackblitz/sdk",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stackblitz/sdk",
-      "version": "1.5.6",
+      "version": "1.6.0",
       "license": "MIT",
       "devDependencies": {
         "microbundle": "^0.3.1",

--- a/sdk/src/helpers.ts
+++ b/sdk/src/helpers.ts
@@ -12,7 +12,7 @@ export function genID() {
 }
 
 export function buildProjectQuery(options?: EmbedOptions) {
-  const params = [];
+  const params: string[] = [];
 
   if (options) {
     if (options.forceEmbedLayout) {


### PR DESCRIPTION
When running `npm run build` to build the sdk files, `tsc` complains about the params array having no type.

This fixes that, plus updates the `package-lock.json` to have the correct version number.