### PR TITLE
fix(sdk): specify VM.editor and VM.preview types

### DIFF
--- a/sdk/src/RDC.ts
+++ b/sdk/src/RDC.ts
@@ -48,7 +48,7 @@ export class RDC {
   }
 
   // Always returns a promise; uniquely ID's messages being sent.
-  request(data: RequestData) {
+  request<T = null>(data: RequestData): Promise<T | null> {
     // Generate request ID
     const id = genID();
     return new Promise((resolve, reject) => {

--- a/sdk/src/VM.ts
+++ b/sdk/src/VM.ts
@@ -1,19 +1,29 @@
 import { RDC } from './RDC';
 
-export interface VMConfig {
+interface VMConfig {
   previewOrigin: string;
+}
+
+interface VMFsDiff {
+  create: { [path: string]: string };
+  destroy: string[];
 }
 
 export class VM {
   private rdc: RDC;
-  public editor: any;
-  public preview: any;
+
+  public editor: {
+    openFile: (path: string) => Promise<null>;
+  };
+
+  public preview: {
+    readonly origin: string;
+  };
 
   constructor(port: MessagePort, config: VMConfig) {
     this.rdc = new RDC(port);
 
-    this.preview = {};
-    Object.defineProperty(this.preview, 'origin', {
+    this.preview = Object.defineProperty({ origin: '' }, 'origin', {
       value: config.previewOrigin,
       writable: false,
     });
@@ -28,21 +38,29 @@ export class VM {
     };
   }
 
-  applyFsDiff(diff: { create: { [path: string]: string }; destroy: string[] }) {
-    // Need to do validations on the DIFF object here.
+  applyFsDiff(diff: VMFsDiff) {
+    const isObject = (val: any) => val !== null && typeof val === 'object';
+    if (!isObject(diff) || !isObject(diff.create)) {
+      throw new Error('Invalid diff object: expected diff.create to be an object.');
+    } else if (!Array.isArray(diff.destroy)) {
+      throw new Error('Invalid diff object: expected diff.create to be an array.');
+    }
+
     return this.rdc.request({
       type: 'SDK_APPLY_FS_DIFF',
       payload: diff,
     });
   }
+
   getFsSnapshot() {
-    return this.rdc.request({
+    return this.rdc.request<{ [path: string]: string }>({
       type: 'SDK_GET_FS_SNAPSHOT',
       payload: {},
     });
   }
+
   getDependencies() {
-    return this.rdc.request({
+    return this.rdc.request<{ [name: string]: string }>({
       type: 'SDK_GET_DEPS_SNAPSHOT',
       payload: {},
     });


### PR DESCRIPTION
Our types for the VM class are lacking:

- `any` for the `editor` and `preview` properties
- `Promise<{}>` (equivalent to `Promise<unknown>` in recent TypeScript I believe?) for all methods, including those that actually return a value.
    - In my tests, we return `null` for all methods on success or when ignored.
    - We return objects of strings _or null_ for `getFsSnapshot` and `getDependencies`.
