### PR TITLE
fix(sdk): make forceEmbedLayout default to true for embed methods 

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stackblitz/sdk",
-  "version": "1.7.0-alpha.0",
+  "version": "1.7.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stackblitz/sdk",
-      "version": "1.7.0-alpha.0",
+      "version": "1.7.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "microbundle": "~0.14.2",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackblitz/sdk",
-  "version": "1.7.0-alpha.0",
+  "version": "1.7.0-alpha.1",
   "description": "SDK for generating and embedding StackBlitz projects.",
   "main": "./bundles/sdk.js",
   "module": "./bundles/sdk.m.js",

--- a/sdk/src/generate.ts
+++ b/sdk/src/generate.ts
@@ -1,5 +1,5 @@
 import { Project, EmbedOptions, OpenOptions } from './interfaces';
-import { buildProjectQuery, openTarget, getOrigin } from './helpers';
+import { openTarget, openUrl } from './helpers';
 
 const SUPPORTED_TEMPLATES: Project['template'][] = [
   'angular-cli',
@@ -62,7 +62,7 @@ function createProjectForm(project: Project) {
 
 export function createProjectFrameHTML(project: Project, options?: EmbedOptions) {
   const form = createProjectForm(project);
-  form.action = `${getOrigin(options)}/run` + buildProjectQuery(options);
+  form.action = openUrl('/run', options);
   form.id = 'sb';
 
   const html = `<html><head><title></title></head><body>${form.outerHTML}<script>document.getElementById('${form.id}').submit();</script></body></html>`;
@@ -72,7 +72,7 @@ export function createProjectFrameHTML(project: Project, options?: EmbedOptions)
 
 export function openNewProject(project: Project, options?: OpenOptions) {
   const form = createProjectForm(project);
-  form.action = `${getOrigin(options)}/run` + buildProjectQuery(options);
+  form.action = openUrl('/run', options);
   form.target = openTarget(options);
 
   document.body.appendChild(form);

--- a/sdk/src/helpers.ts
+++ b/sdk/src/helpers.ts
@@ -1,15 +1,7 @@
-import { ProjectOptions, EmbedOptions, OpenOptions } from './interfaces';
+import { EmbedOptions, OpenOptions } from './interfaces';
 
 const DEFAULT_ORIGIN = 'https://stackblitz.com';
 const DEFAULT_FRAME_HEIGHT = '300';
-
-export function getOrigin(options?: ProjectOptions | OpenOptions | EmbedOptions) {
-  if (options && typeof options.origin === 'string') {
-    return options.origin;
-  }
-
-  return DEFAULT_ORIGIN;
-}
 
 /**
  * Pseudo-random id string for internal accounting.
@@ -19,9 +11,28 @@ export function genID() {
   return Math.random().toString(36).slice(2, 6) + Math.random().toString(36).slice(2, 6);
 }
 
-export function buildProjectQuery(options?: EmbedOptions) {
-  if (!options) return '';
+export function openUrl(route: string, options?: OpenOptions) {
+  return `${getOrigin(options)}${route}${buildProjectQuery(options)}`;
+}
 
+export function embedUrl(route: string, options?: EmbedOptions) {
+  const config: EmbedOptions = {
+    forceEmbedLayout: true,
+  };
+  if (options && typeof options === 'object') {
+    Object.assign(config, options);
+  }
+  return `${getOrigin(config)}${route}${buildProjectQuery(config)}`;
+}
+
+function getOrigin(options: OpenOptions | EmbedOptions = {}) {
+  if (typeof options.origin === 'string') {
+    return options.origin;
+  }
+  return DEFAULT_ORIGIN;
+}
+
+function buildProjectQuery(options: OpenOptions | EmbedOptions = {}) {
   const params: string[] = [];
 
   if (options.forceEmbedLayout) {
@@ -101,11 +112,11 @@ export function openTarget(options?: OpenOptions) {
 }
 
 function setFrameDimensions(frame: HTMLIFrameElement, options?: EmbedOptions) {
-  if (options) {
-    if (options.hasOwnProperty('height')) {
+  if (options && typeof options === 'object') {
+    if (Object.hasOwnProperty.call(options, 'height')) {
       frame.height = `${options.height}`;
     }
-    if (options.hasOwnProperty('width')) {
+    if (Object.hasOwnProperty.call(options, 'width')) {
       frame.width = `${options.width}`;
     }
   }

--- a/sdk/src/helpers.ts
+++ b/sdk/src/helpers.ts
@@ -94,17 +94,17 @@ export function replaceAndEmbed(
   parent.parentNode.replaceChild(frame, parent);
 }
 
-export function elementFromElementOrId(elementOrId: string | HTMLElement) {
-  if ('string' === typeof elementOrId) {
+export function findElement(elementOrId: string | HTMLElement) {
+  if (typeof elementOrId === 'string') {
     const element = document.getElementById(elementOrId);
-    if (element !== null) {
-      return element;
+    if (!element) {
+      throw new Error(`Could not find element with id '${elementOrId}'`);
     }
+    return element;
   } else if (elementOrId instanceof HTMLElement) {
     return elementOrId;
   }
-
-  throw new Error('Invalid Element');
+  throw new Error(`Invalid element: ${elementOrId}`);
 }
 
 export function openTarget(options?: OpenOptions) {

--- a/sdk/src/helpers.ts
+++ b/sdk/src/helpers.ts
@@ -32,14 +32,10 @@ export function buildProjectQuery(options?: EmbedOptions) {
     params.push('ctl=1');
   }
 
-  if (typeof options.openFile === 'string') {
-    params.push(`file=${options.openFile}`);
-  } else if (Array.isArray(options.openFile)) {
-    options.openFile.forEach((file) => {
-      if (typeof file === 'string') {
-        params.push(`file=${file}`);
-      }
-    });
+  for (const file of Array.isArray(options.openFile) ? options.openFile : [options.openFile]) {
+    if (typeof file === 'string' && file.trim() !== '') {
+      params.push(`file=${encodeURIComponent(file.trim())}`);
+    }
   }
 
   if (options.view === 'preview' || options.view === 'editor') {

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -96,7 +96,7 @@ export interface ProjectOptions {
   hideNavigation?: boolean;
   /**
    * Use the “embed” layout of the editor.
-   * Defaults to `false`; we recommend setting it to true when using the `embedProject*` methods.
+   * Defaults to `true` for `embedProject*` methods, and `false` for `openProject*` methods
    */
   forceEmbedLayout?: boolean;
   /**

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -96,7 +96,10 @@ export interface ProjectOptions {
   hideNavigation?: boolean;
   /**
    * Use the “embed” layout of the editor.
-   * Defaults to `true` for `embedProject*` methods, and `false` for `openProject*` methods
+   * 
+   * Defaults to `true` for `embedProject*` methods, and `false` for `openProject*` methods.
+   * 
+   * @deprecated May be removed in a future release.
    */
   forceEmbedLayout?: boolean;
   /**

--- a/sdk/src/lib.ts
+++ b/sdk/src/lib.ts
@@ -2,13 +2,7 @@ import type { Project, OpenOptions, EmbedOptions } from './interfaces';
 import type { VM } from './VM';
 import { Connection, getConnection } from './connection';
 import { openNewProject, createProjectFrameHTML } from './generate';
-import {
-  replaceAndEmbed,
-  buildProjectQuery,
-  elementFromElementOrId,
-  openTarget,
-  getOrigin,
-} from './helpers';
+import { elementFromElementOrId, embedUrl, openTarget, openUrl, replaceAndEmbed } from './helpers';
 
 /**
  * Get a VM instance for an existing StackBlitz project iframe.
@@ -32,10 +26,9 @@ export function openProject(project: Project, options?: OpenOptions) {
  * Open an existing StackBlitz project in a new tab (or in the current window).
  */
 export function openProjectId(projectId: string, options?: OpenOptions) {
-  window.open(
-    `${getOrigin(options)}/edit/${projectId}${buildProjectQuery(options)}`,
-    openTarget(options)
-  );
+  const url = openUrl(`/edit/${projectId}`, options);
+  const target = openTarget(options);
+  window.open(url, target);
 }
 
 /**
@@ -47,10 +40,9 @@ export function openProjectId(projectId: string, options?: OpenOptions) {
  *     sdk.openGithubProject('some/repository/tree/some-branch');
  */
 export function openGithubProject(repoSlug: string, options?: OpenOptions) {
-  window.open(
-    `${getOrigin(options)}/github/${repoSlug}${buildProjectQuery(options)}`,
-    openTarget(options)
-  );
+  const url = openUrl(`/github/${repoSlug}`, options);
+  const target = openTarget(options);
+  window.open(url, target);
 }
 
 /**
@@ -87,7 +79,7 @@ export function embedProjectId(
 ): Promise<VM> {
   const element = elementFromElementOrId(elementOrId);
   const frame = document.createElement('iframe');
-  frame.src = `${getOrigin(options)}/edit/${projectId}${buildProjectQuery(options)}`;
+  frame.src = embedUrl(`/edit/${projectId}`, options);
 
   replaceAndEmbed(element, frame, options);
 
@@ -106,7 +98,7 @@ export function embedGithubProject(
 ): Promise<VM> {
   const element = elementFromElementOrId(elementOrId);
   const frame = document.createElement('iframe');
-  frame.src = `${getOrigin(options)}/github/${repoSlug}${buildProjectQuery(options)}`;
+  frame.src = embedUrl(`/github/${repoSlug}`, options);
 
   replaceAndEmbed(element, frame, options);
 

--- a/sdk/src/lib.ts
+++ b/sdk/src/lib.ts
@@ -2,7 +2,7 @@ import type { Project, OpenOptions, EmbedOptions } from './interfaces';
 import type { VM } from './VM';
 import { Connection, getConnection } from './connection';
 import { openNewProject, createProjectFrameHTML } from './generate';
-import { elementFromElementOrId, embedUrl, openTarget, openUrl, replaceAndEmbed } from './helpers';
+import { embedUrl, findElement, openTarget, openUrl, replaceAndEmbed } from './helpers';
 
 /**
  * Get a VM instance for an existing StackBlitz project iframe.
@@ -55,7 +55,7 @@ export function embedProject(
   project: Project,
   options?: EmbedOptions
 ): Promise<VM> {
-  const element = elementFromElementOrId(elementOrId);
+  const element = findElement(elementOrId);
   const html = createProjectFrameHTML(project, options);
   const frame = document.createElement('iframe');
 
@@ -77,7 +77,7 @@ export function embedProjectId(
   projectId: string,
   options?: EmbedOptions
 ): Promise<VM> {
-  const element = elementFromElementOrId(elementOrId);
+  const element = findElement(elementOrId);
   const frame = document.createElement('iframe');
   frame.src = embedUrl(`/edit/${projectId}`, options);
 
@@ -96,7 +96,7 @@ export function embedGithubProject(
   repoSlug: string,
   options?: EmbedOptions
 ): Promise<VM> {
-  const element = elementFromElementOrId(elementOrId);
+  const element = findElement(elementOrId);
   const frame = document.createElement('iframe');
   frame.src = embedUrl(`/github/${repoSlug}`, options);
 


### PR DESCRIPTION
A couple more updates for the upcoming 1.7.0 release.

### Breaking-ish change

When using one of the `StackBlitzSDK.embedProject*` methods to generate a `<iframe>` embedding a StackBlitz project, and when the user doesn't provide a `forceEmbedLayout` value in `EmbedOptions`, then we set `forceEmbedLayout` to `true` instead of `undefined`.

This results in generated URLs having the `embed=1` query string parameter and using the embed layout, instead of using the generic editor layout (with a top bar, login button, forking on saving as an anonymous user, etc.).

According to @EricSimons, the current behavior is a bug dating back 4+ years ago. So a fix would be welcome to make it more likely that embeds actually use the embed layout.

It's still a change in behavior, and while many users might see it as a feature upgrade, others might be relying on embedding the StackBlitz editor with the normal (non-embed) layout, which is kinda unsupported and can behave strangely but who knows, there might be a few people out there that make it work.

For those users of the SDK, their options would be remaining on `@stackblitz/sdk@1.6.0` or lower, or providing `{ forceEmbedLayout: false }` in options.

Example usage:

```js
// Default, embed layout
sdk.embedProjectId('sb-embed', 'my-cool-project', {
  openFile: 'src/main.ts',
});

// Or opt out of the embed layout (not officially supported!)
sdk.embedProjectId('sb-embed', 'my-cool-project', {
  forceEmbedLayout: true,
  openFile: 'src/main.ts',
});
```

### A couple extra fixes for the road

- Encode file names in file= query string parameter
- Improve error message when not finding a target element id
