### PR TITLE
feat(sdk): add support for the terminalHeight param

### DIFF
--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -80,6 +80,14 @@ export interface ProjectOptions {
    */
   theme?: UiThemeOption;
   /**
+   * Height of the Terminal panel below the editor (as a percentage number).
+   * 
+   * Values such as `0` and `100` may not be applied as-is, but result instead in the minimum or maximum height allowed for the Terminal.
+   *
+   * The Terminal only appears in WebContainers-based projects.
+   */
+  terminalHeight?: number;
+  /**
    * Height of the Console panel below the preview page (as a percentage number, between `0` and `100`).
    *
    * By default, the Console will appear collapsed, and can be opened by users.

--- a/sdk/src/params.ts
+++ b/sdk/src/params.ts
@@ -11,6 +11,7 @@ const generators: Record<keyof Options, (value: any) => string> = {
   hideNavigation: (value: Options['hideNavigation']) => trueParam('hideNavigation', value),
   showSidebar: (value: Options['showSidebar']) => booleanParam('showSidebar', value),
   openFile: (value: Options['openFile']) => stringParams('file', value).join('&'),
+  terminalHeight: (value: Options['terminalHeight']) => percentParam('terminalHeight', value),
   theme: (value: Options['theme']) => enumParam('theme', ['light', 'dark'], value),
   view: (value: Options['view']) => enumParam('view', ['preview', 'editor'], value),
 };


### PR DESCRIPTION
We added a `terminalHeight` URL parameter for the StackBlitz editor, but it wasn't exposed in the SDK yet.