### PR TITLE
fix(sdk): lowercase hidedevtools and devtoolsheight params

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,21 +1,25 @@
 # @stackblitz/sdk changelog
 
+## v1.8.1 (2022-11-10)
+
+- Fixed the case of the URL query parameters for the `hideDevTools` and `devToolsHeight` options, for backwards compatibility with StackBlitz EE. (#2154)
+
 ## v1.8.0 (2022-06-09)
 
 - Added a `terminalHeight` option, used to set a preferred height for the Terminal in WebContainers-based projects. (#1891)
 
 ## v1.7.0 (2022-05-09)
 
-- TypeScript: improved the precision and inline documentation of types such as `Project`, `EmbedOptions`, `OpenOptions` and `VM`. Made those types directly importable with `import type { Project } from '@stackblitz/sdk'` (#1775, #1779, #1837).
-- Added support for opening multiple files in an embedded projects with the `vm.editor.openFile` method (#1810).
-- Added new methods to the `VM` class for controlling the embedded editor’s UI: `vm.editor.setCurrentFile`, `vm.editor.setTheme`, `vm.editor.setView`, `vm.editor.showSidebar`, `vm.preview.getUrl`, `vm.preview.setUrl` (#1810, #1837).
-- Added new `showSidebar` option (#1837).
-- Added source maps to the published bundle files (#1776).
-- Fixed the default value of the `forceEmbedLayout` option (#1817).
+- TypeScript: improved the precision and inline documentation of types such as `Project`, `EmbedOptions`, `OpenOptions` and `VM`. Made those types directly importable with `import type { Project } from '@stackblitz/sdk'`. (#1775, #1779, #1837)
+- Added support for opening multiple files in an embedded projects with the `vm.editor.openFile` method. (#1810)
+- Added new methods to the `VM` class for controlling the embedded editor’s UI: `vm.editor.setCurrentFile`, `vm.editor.setTheme`, `vm.editor.setView`, `vm.editor.showSidebar`, `vm.preview.getUrl`, `vm.preview.setUrl`. (#1810, #1837)
+- Added new `showSidebar` option. (#1837)
+- Added source maps to the published bundle files. (#1776)
+- Fixed the default value of the `forceEmbedLayout` option. (#1817)
 
 ## v1.6.0 (2022-03-02)
 
-- Add support for opening multiple files with the openFile parameter, with support for multiple tabs (`openFile: 'index.html,src/index.js'`) and split editor panes (`openFile: ['index.html', 'src/index.js]`) (#1758).
+- Add support for opening multiple files with the openFile parameter, with support for multiple tabs (`openFile: 'index.html,src/index.js'`) and split editor panes (`openFile: ['index.html', 'src/index.js]`). (#1758)
 
 ## v1.5.6 (2022-02-04)
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackblitz/sdk",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "SDK for generating and embedding StackBlitz projects.",
   "main": "./bundles/sdk.js",
   "module": "./bundles/sdk.m.js",
@@ -14,7 +14,10 @@
   },
   "files": [
     "bundles",
-    "typings"
+    "typings",
+    "CHANGELOG.md",
+    "LICENSE.md",
+    "README.md"
   ],
   "author": "Eric Simons",
   "license": "MIT",

--- a/sdk/src/params.ts
+++ b/sdk/src/params.ts
@@ -4,9 +4,9 @@ type Options = Omit<OpenOptions & EmbedOptions, 'origin' | 'newWindow' | 'height
 
 const generators: Record<keyof Options, (value: any) => string> = {
   clickToLoad: (value: Options['clickToLoad']) => trueParam('ctl', value),
-  devToolsHeight: (value: Options['devToolsHeight']) => percentParam('devToolsHeight', value),
+  devToolsHeight: (value: Options['devToolsHeight']) => percentParam('devtoolsheight', value),
   forceEmbedLayout: (value: Options['forceEmbedLayout']) => trueParam('embed', value),
-  hideDevTools: (value: Options['hideDevTools']) => trueParam('hideDevTools', value),
+  hideDevTools: (value: Options['hideDevTools']) => trueParam('hidedevtools', value),
   hideExplorer: (value: Options['hideExplorer']) => trueParam('hideExplorer', value),
   hideNavigation: (value: Options['hideNavigation']) => trueParam('hideNavigation', value),
   showSidebar: (value: Options['showSidebar']) => booleanParam('showSidebar', value),


### PR DESCRIPTION
We (well, I) introduced a regression in version 1.7.0 of the SDK by renaming the hidedevtools and devtoolsheight URL query parameters to hideDevTools and devToolsHeight.

See: https://github.com/stackblitz/core/commit/5e89b03320cd222f2b8cf19ae92820769f4671b5#diff-4db4b7030103b2f5677a33713b8c50bc15c70c96aafdf68adcd25f6f6a141a62L54-L65

While stackblitz.com does handle query parameters insensitive of case, StackBlitz EE may not (depending on the deployed version).

For backwards compatibility, those parameters should keep their original case.