### PR TITLE
fix(sdk): escape brackets in file paths with embedProject/openProject

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @stackblitz/sdk changelog
 
+## v1.8.2 (2023-01-26)
+
+- Fixed using the characters `[]` in file paths with the `embedProject` and `openProject` methods. (#2295)
+
 ## v1.8.1 (2022-11-10)
 
 - Fixed the case of the URL query parameters for the `hideDevTools` and `devToolsHeight` options, for backwards compatibility with StackBlitz EE. (#2154)

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stackblitz/sdk",
-  "version": "1.8.0",
+  "version": "1.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stackblitz/sdk",
-      "version": "1.8.0",
+      "version": "1.8.2",
       "license": "MIT",
       "devDependencies": {
         "microbundle": "~0.14.2",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stackblitz/sdk",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "SDK for generating and embedding StackBlitz projects.",
   "main": "./bundles/sdk.js",
   "module": "./bundles/sdk.m.js",

--- a/sdk/src/generate.ts
+++ b/sdk/src/generate.ts
@@ -10,6 +10,16 @@ function createHiddenInput(name: string, value: string) {
   return input;
 }
 
+/**
+ * Encode file paths for use in input name attributes.
+ * We need to replace square brackets (as used by Next.js, SvelteKit, etc.),
+ * with custom escape sequences. Important: do not encodeURIComponent the
+ * whole path, for compatibility with the StackBlitz backend.
+ */
+function bracketedFilePath(path: string) {
+  return `[${path.replace(/\[/g, '%5B').replace(/\]/g, '%5D')}]`;
+}
+
 function createProjectForm(project: Project) {
   if (!PROJECT_TEMPLATES.includes(project.template)) {
     const names = PROJECT_TEMPLATES.map((t) => `'${t}'`).join(', ');
@@ -43,8 +53,10 @@ function createProjectForm(project: Project) {
   }
 
   Object.keys(project.files).forEach((path) => {
-    if (typeof project.files[path] === 'string') {
-      form.appendChild(createHiddenInput(`project[files][${path}]`, project.files[path]));
+    const name = 'project[files]' + bracketedFilePath(path);
+    const value = project.files[path];
+    if (typeof value === 'string') {
+      form.appendChild(createHiddenInput(name, value));
     }
   });
 


### PR DESCRIPTION
Frameworks such as Next.js and SvelteKit use square brackets in their file-based routing API. For instance a SvelteKit route may use this file path:

```
src/routes/hello/[...path]/+layout.ts
```

With the form posting method used by the `embedProject` and `openProject` methods, this currently gets turned into the following input name:

```
project[files][src/routes/hello/[...path]/+layout.ts]
```

Which trips up the StackBlitz backend.

This PR turns the `[]` characters in file paths, and only those characters, into their corresponding URI-escaped values. The StackBlitz backend will do the corresponding decoding. Note that we do not want to `encodeURIComponent` the full file path, because that would break backwards compatibility with StackBlitz Enterprise Edition.
