### PR TITLE
Rewrite README.md to make clear that all code is archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
 # StackBlitz — Your local env, now in the browser
 
-[![Chat](https://img.shields.io/badge/chat-on%20discord-7289da.svg)](https://discord.gg/stackblitz)
+[![Chat on Discord](https://img.shields.io/badge/chat-on%20discord-7289da.svg)](https://discord.gg/stackblitz)
 
-Welcome to the StackBlitz GitHub repo!
+Welcome to the StackBlitz GitHub repository!
 
-This repo serves as our primary way of [keeping track of bugs](https://github.com/stackblitz/core/issues) & central location where we publish our internal packages. If you have any questions/ideas/feedback, feel free to open an issue or come chat with us on [Discord](https://discord.gg/stackblitz)!
+This repository serves as our primary way of [keeping track of bugs](https://github.com/stackblitz/core/issues). If you have any questions/ideas/feedback, feel free to open an issue or come chat with us on [Discord](https://discord.gg/stackblitz)!
 
-### Just learning about StackBlitz?
+## Documentation
 
-Take a look at our [announcement post](https://medium.com/@ericsimons/stackblitz-online-vs-code-ide-for-angular-react-7d09348497f4) which covers our core functionality, feature set and motivations behind the project.
+Check out our docs at [developer.stackblitz.com](https://developer.stackblitz.com/).
 
-### Curious how our technology works?
+## Archived packages
 
-We recommend [reading the write-up](https://medium.com/@ericsimons/introducing-turbo-5x-faster-than-yarn-npm-and-runs-natively-in-browser-cc2c39715403) we did and exploring the code in this GitHub repo.
+This repository contains an archive of internal packages that constituted the original 2017 version of StackBlitz. Read the [2017 announcement post](https://medium.com/@ericsimons/stackblitz-online-vs-code-ide-for-angular-react-7d09348497f4) which covers the initial core functionality, feature set and motivations behind the project.
 
-### Documentation
-
-__Check out our docs at [developer.stackblitz.com](https://developer.stackblitz.com/)__
+Curious how that technology works? We recommend [reading the write-up](https://medium.com/@ericsimons/introducing-turbo-5x-faster-than-yarn-npm-and-runs-natively-in-browser-cc2c39715403) we did and exploring the code in this GitHub repo.


### PR DESCRIPTION
ℹ️ This PR targets the `archive` branch, not the `main` branch.


This PR is part of a small project to make the `stackblitz/core` repository more user-friendly and a better reflection of StackBlitz products and technology.

One part of this project is removing legacy code this is not used anymore and does not meaningfully represent the current feature set and capabilities of StackBlitz and its SDK and APIs.

But instead of removing it wholesale, we probably want to *archive* this code and keep it around for historical reasons. It would stay in Git history, but it’s probably better to have a place to point people to if they want to check it out.

My plan for having this “place to point people to”:

1. Make a new `archive` branch that duplicates `main` and contains all legacy code. (Done.)
2. Update its `README.md` to call out that code in this repository is legacy/archived. (This PR.)

